### PR TITLE
v0.24.1 - Renamed Macro bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
-project(sxbp VERSION 0.24.0 LANGUAGES C)
+project(sxbp VERSION 0.24.1 LANGUAGES C)
 
 # set default C standard to use (C99) if not already set
 if(NOT DEFINED LIBSXBP_C_STANDARD)

--- a/sxbp/render_backends/backend_png.c
+++ b/sxbp/render_backends/backend_png.c
@@ -166,8 +166,8 @@ sxbp_status_t sxbp_render_backend_png(
     metadata[2].key = "Copyright";
     metadata[2].text = "Copyright Joshua Saxby";
     metadata[3].key = "Software";
-    // SAXBOSPIRAL_VERSION_STRING is a macro that expands to a double-quoted string
-    metadata[3].text = "libsxbp v" SAXBOSPIRAL_VERSION_STRING;
+    // LIBSXBP_VERSION_STRING is a macro that expands to a double-quoted string
+    metadata[3].text = "libsxbp v" LIBSXBP_VERSION_STRING;
     metadata[4].key = "Comment";
     metadata[4].text = "https://github.com/saxbophone/libsxbp";
     // set compression of each metadata key


### PR DESCRIPTION
63fe810 fixes a bug where a macro was not renamed in source (it was renamed in the build scripts).