### PR TITLE
v0.24.2 - PNG Output bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
-project(sxbp VERSION 0.24.1 LANGUAGES C)
+project(sxbp VERSION 0.24.2 LANGUAGES C)
 
 # set default C standard to use (C99) if not already set
 if(NOT DEFINED LIBSXBP_C_STANDARD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ set_target_properties(
 # link libsxbp with C math library
 target_link_libraries(sxbp m)
 # Link libsxbp with libpng so we get libpng symbols (if support enabled)
-if(SXBP_PNG_SUPPORT)
+if(LIBSXBP_PNG_SUPPORT)
     target_link_libraries(sxbp ${PNG_LIBRARY})
 endif()
 

--- a/sxbp/render_backends/backend_png.c
+++ b/sxbp/render_backends/backend_png.c
@@ -28,13 +28,10 @@
  */
 #include <assert.h>
 // only include these extra dependencies if support for PNG output was enabled
-#ifdef SAXBOSPIRAL_PNG_SUPPORT
+#ifdef LIBSXBP_PNG_SUPPORT
 #include <stdlib.h>
 #include <string.h>
-#endif
 
-// only include libpng if support for it was enabled
-#ifdef SAXBOSPIRAL_PNG_SUPPORT
 #include <png.h>
 #endif
 
@@ -48,7 +45,7 @@ extern "C"{
 #endif
 
 // only define the following private functions if libpng support was enabled
-#ifdef SAXBOSPIRAL_PNG_SUPPORT
+#ifdef LIBSXBP_PNG_SUPPORT
 // private custom libPNG buffer write function
 static void buffer_write_data(
     png_structp png_ptr, png_bytep data, png_size_t length
@@ -93,7 +90,14 @@ static void cleanup_png_lib(
         free(row);
     }
 }
-#endif // SAXBOSPIRAL_PNG_SUPPORT
+#endif // LIBSXBP_PNG_SUPPORT
+
+// flag for whether PNG output support has been compiled in based, on macro
+#ifdef LIBSXBP_PNG_SUPPORT
+const bool SXBP_PNG_SUPPORT = true;
+#else
+const bool SXBP_PNG_SUPPORT = false;
+#endif
 
 /*
  * given a bitmap_t struct and a pointer to a blank buffer_t, write the bitmap
@@ -112,7 +116,7 @@ sxbp_status_t sxbp_render_backend_png(
     assert(bitmap.pixels != NULL);
     assert(buffer->bytes == NULL);
     // only do PNG operations if support is enabled
-    #ifndef SAXBOSPIRAL_PNG_SUPPORT
+    #ifndef LIBSXBP_PNG_SUPPORT
     // return SXBP_NOT_IMPLEMENTED
     return SXBP_NOT_IMPLEMENTED;
     #else
@@ -206,7 +210,7 @@ sxbp_status_t sxbp_render_backend_png(
     // status ok
     result = SXBP_OPERATION_OK;
     return result;
-    #endif // SAXBOSPIRAL_PNG_SUPPORT
+    #endif // LIBSXBP_PNG_SUPPORT
 }
 
 #ifdef __cplusplus

--- a/sxbp/render_backends/backend_png.h
+++ b/sxbp/render_backends/backend_png.h
@@ -37,6 +37,9 @@
 extern "C"{
 #endif
 
+// flag for whether PNG output support has been compiled in based, on macro
+extern const bool SXBP_PNG_SUPPORT;
+
 /*
  * given a bitmap_t struct and a pointer to a blank buffer_t, write the bitmap
  * data as a PNG image to the buffer, using libpng.

--- a/sxbp/saxbospiral.c
+++ b/sxbp/saxbospiral.c
@@ -37,12 +37,6 @@ const sxbp_version_t LIB_SXBP_VERSION = {
     .patch = LIBSXBP_VERSION_PATCH,
     .string = LIBSXBP_VERSION_STRING,
 };
-// flag for whether PNG output support has been compiled in based, on macro
-#ifdef LIBSXBP_PNG_SUPPORT
-const bool SXBP_PNG_SUPPORT = true;
-#else
-const bool SXBP_PNG_SUPPORT = false;
-#endif
 
 /*
  * computes a version_hash_t for a given version_t,

--- a/sxbp/saxbospiral.h
+++ b/sxbp/saxbospiral.h
@@ -41,8 +41,6 @@ typedef struct sxbp_version_t {
 } sxbp_version_t;
 
 extern const sxbp_version_t LIB_SXBP_VERSION;
-// flag for whether PNG output support has been compiled in based, on macro
-extern const bool SXBP_PNG_SUPPORT;
 
 // used for indexing and comparing different versions in order
 typedef uint32_t sxbp_version_hash_t;


### PR DESCRIPTION
This bugfix version fixes an issue where PNG output could never be enabled (caused by some symbols which were missed in the renaming).