### PR TITLE
v0.26.1 - Minimum file format version bugfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # begin basic metadata
 cmake_minimum_required(VERSION 3.0)
 
-project(sxbp VERSION 0.26.0 LANGUAGES C)
+project(sxbp VERSION 0.26.1 LANGUAGES C)
 
 # set default C standard to use (C99) if not already set
 if(NOT DEFINED LIBSXBP_C_STANDARD)

--- a/sxbp/serialise.c
+++ b/sxbp/serialise.c
@@ -128,8 +128,9 @@ sxbp_serialise_result_t sxbp_load_spiral(
         .minor = load_uint16_t(&buffer, 6),
         .patch = load_uint16_t(&buffer, 8),
     };
-    // we don't accept anything less than v0.25.0, so the min is v0.25.0
-    sxbp_version_t min_version = { .major = 0, .minor = 25, .patch = 0, };
+    // we don't accept anything less than v0.26.0, so the min is v0.26.0
+    // TODO: Add this as a library constant - to add in next minor release
+    sxbp_version_t min_version = { .major = 0, .minor = 26, .patch = 0, };
     // check for version compatibility
     if(sxbp_version_less_than(buffer_version, min_version)) {
         // check failed


### PR DESCRIPTION
Fixes a tiny weeny bug (#170) where the minimum supported file format version was incorrectly specified as **v0.25.0** when it is in fact **v0.26.0**.